### PR TITLE
feat: switch stock API to alpha vantage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ fetch_stock(["AAPL"])
 PY
 ```
 
+#### 환경 변수
+주가 데이터를 조회하려면 [Alpha Vantage](https://www.alphavantage.co/) API 키가 필요합니다.
+아래와 같이 `ALPHAVANTAGE_API_KEY` 환경 변수에 키를 설정하세요.
+
+```bash
+export ALPHAVANTAGE_API_KEY=YOUR_KEY
+```
+
 =======
 
 


### PR DESCRIPTION
## Summary
- use Alpha Vantage to fetch stock prices and cache results
- document ALPHAVANTAGE_API_KEY requirement in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890dc67c71c8327b01e074ddbfd064f