### PR TITLE
feat: switch stock API to alpha vantage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NEWS_API_KEY=your_news_api_key
+TWITTER_BEARER_TOKEN=your_twitter_bearer_token
+ALPHAVANTAGE_API_KEY=your_alpha_vantage_key
+DATABASE_DSN=postgres://user:pass@localhost/db
+REDIS_URL=redis://localhost:6379/0

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ fetch_stock(["AAPL"])
 PY
 ```
 
+#### 환경 변수
+환경 변수 예시는 저장소의 `.env.example` 파일을 참고하여 `.env`로 복사해 사용하세요.
+주가 데이터를 조회하려면 [Alpha Vantage](https://www.alphavantage.co/) API 키가 필요합니다.
+아래와 같이 `ALPHAVANTAGE_API_KEY` 환경 변수에 키를 설정하세요.
+
+```bash
+export ALPHAVANTAGE_API_KEY=YOUR_KEY
+```
+
 =======
 
 


### PR DESCRIPTION
## Summary
- use Alpha Vantage to fetch stock prices and cache results
- document ALPHAVANTAGE_API_KEY requirement in README
- add example env file with all required variables

## Testing
- `ALPHAVANTAGE_API_KEY=demo python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890dc67c71c8327b01e074ddbfd064f